### PR TITLE
RabbitMQ Collect Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+.idea
+tmp/
+*.tmp
+scratch/
+build/
+*.swp
+profile.cov
+gin-bin
+
+# we don't vendor godep _workspace
+**/Godeps/_workspace/**
+
+# OSX stuff
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: true
+services:
+- rabbitmq
+language: go
+go:
+- 1.4.3
+- 1.5.3
+before_install:
+- go get github.com/tools/godep
+- if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+env:
+  global:
+    - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap-plugin-collector-rabbitmq
+  matrix:
+    - TEST=unit
+    - TEST=integration
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $SNAP_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# snap collector plugin - rabbitmq
+
+1. [Contributing Code](#contributing-code)
+2. [Contributing Examples](#contributing-examples)
+3. [Contribute Elsewhere](#contribute-elsewhere)
+4. [Thank You](#thank-you)
+
+This repository has dedicated developers from Intel working on updates. The most helpful way to contribute is by reporting your experience through issues. Issues may not be updated while we review internally, but they're still incredibly appreciated.
+
+## Contributing Code
+**_IMPORTANT_**: We encourage contributions to the project from the community. We ask that you keep the following guidelines in mind when planning your contribution.
+
+* Whether your contribution is for a bug fix or a feature request, **create an [Issue](https://github.com/intelsdi-x/snap-plugin-collector-rabbitmq/issues)** and let us know what you are thinking
+* **For bugs**, if you have already found a fix, feel free to submit a Pull Request referencing the Issue you created
+* **For feature requests**, we want to improve upon the library incrementally which means small changes at a time. In order ensure your PR can be reviewed in a timely manner, please keep PRs small, e.g. <10 files and <500 lines changed. If you think this is unrealistic, then mention that within the issue and we can discuss it
+
+Once you're ready to contribute code back to this repo, start with these steps:
+
+* Fork the appropriate sub-projects that are affected by your change
+* Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`  
+	```
+	$ git clone https://github.com/<yourGithubID>/snap-plugin-collector-rabbitmq.git
+	```
+* Create a topic branch for your change and checkout that branch  
+    ```
+    $ git checkout -b some-topic-branch
+    ```
+* Make your changes and run the test suite if one is provided (see below)
+* Commit your changes and push them to your fork
+* Open a pull request for the appropriate project
+* Contributors will review your pull request, suggest changes, and merge it when it’s ready and/or offer feedback
+* To report a bug or issue, please open a new issue against this repository
+
+If you have questions feel free to contact the [maintainers](README.md#maintainers).
+
+## Contributing Examples
+The most immediately helpful way you can benefit this project is by cloning the repository, adding some further examples and submitting a pull request. 
+
+Have you written a blog post about how you use [snap](http://github.com/intelsdi-x/snap) and/or this plugin? Send it to us!
+
+## Contribute Elsewhere
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap.
+
+## Thank You
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,61 @@
+{
+	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-rabbitmq",
+	"GoVersion": "go1.5",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.7.3",
+			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
+			"Comment": "v0.11.0-beta",
+			"Rev": "42d9567651258bba268d94701eb171458e459645"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/core",
+			"Comment": "v0.11.0-beta",
+			"Rev": "42d9567651258bba268d94701eb171458e459645"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
+			"Comment": "v0.11.0-beta",
+			"Rev": "42d9567651258bba268d94701eb171458e459645"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
+			"Comment": "v0.11.0-beta",
+			"Rev": "42d9567651258bba268d94701eb171458e459645"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
+			"Comment": "v0.11.0-beta",
+			"Rev": "42d9567651258bba268d94701eb171458e459645"
+		},
+		{
+			"ImportPath": "github.com/jtolds/gls",
+			"Rev": "f1ac7f4f24f50328e6bc838ca4437d1612a0243c"
+		},
+		{
+			"ImportPath": "github.com/smartystreets/assertions",
+			"Comment": "1.5.0-379-g75acd40",
+			"Rev": "75acd402ca38dc205641a826bb58b9de014926dd"
+		},
+		{
+			"ImportPath": "github.com/smartystreets/goconvey/convey",
+			"Comment": "1.5.0-386-geb2e83c",
+			"Rev": "eb2e83c1df892d2c9ad5a3c85672da30be585dfd"
+		},
+		{
+			"ImportPath": "github.com/streadway/amqp",
+			"Rev": "6a378341a305bfbc252e8a6638f16cf443221997"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "c1cd2254a6dd314c9d73c338c12688c9325d85c6"
+		}
+	]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,243 @@
-# snap-plugin-collector-rabbitmq
-snap plugin for collecting metrics for a Rabbitmq node or cluster through the management API
+# snap collector plugin - rabbitmq-collector
+snap plugin for collecting metrics from a RabbitMQ node or cluster through the RabbitMQ
+mamagement API. 
+
+It's used in the [snap framework](http://github.com:intelsdi-x/snap).
+
+1. [Getting Started](#getting-started)
+  * [System Requirements](#system-requirements)
+  * [Installation](#installation)
+  * [Configuration and Usage](configuration-and-usage)
+2. [Documentation](#documentation)
+  * [Collected Metrics](#collected-metrics)
+  * [Examples](#examples)
+  * [Roadmap](#roadmap)
+3. [Community Support](#community-support)
+4. [Contributing](#contributing)
+5. [License](#license-and-authors)
+6. [Acknowledgements](#acknowledgements)
+
+
+## Getting Started
+### System Requirements
+
+* RabbitMQ node or cluster
+* RabbitMQ management plugin loaded on a node or a node in a cluster
+* Credentials for reading from the RabbitMQ node or cluster
+
+### Operating Systems
+All operating systems currently supported by snap:
+* Linux/amd64
+* Darwin/amd64
+
+### Installation
+#### Download the rabbitmq-collector plugin binary
+You can get the pre-built binaries for your OS and architecture at snap's [GitHub Releases](https://github.com/intelsdi-x/snap/releases) page.
+
+#### To build the plugin binary
+Clone repo into `$GOPATH/src/github.com/intelsdi-x/`:
+
+```
+$ git clone https://github.com/intelsdi-x/snap-plugin-collector-rabbitmq.git
+```
+
+Build the plugin by running make within the cloned repo:
+
+```
+$ cd $GOPATH/src/intelsdi-x/snap-plugin-collector-rabbitmq
+$ make
+```
+
+This builds the plugin in `build/rootfs/`
+
+
+### Configuration and Usage
+* Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
+* The url, user, and password for accessing the RabbitMQ Management API to gather metrics from. The url,
+user, and password can be passed via config to the snap framework on start or via the task manifest as part
+of the config for the metrics to collect.
+
+## Documentation
+
+### Collected Metrics
+This plugin as the ability to collect the following metrics:
+
+#### Nodes
+
+Namespace | Data Type | Description
+----------|-----------|----------------------
+/intel/rabbitmq/node/{name}/disk_free | int | Available disk space on the node
+/intel/rabbitmq/node/{name}/disk_free_details/rate | float64 | Rate of available disk space usage on the node
+/intel/rabbitmq/node/{name}/fd_used | int | Number of file descriptors in use
+/intel/rabbitmq/node/{name}/fd_used_details/rate | float64 | Rate of file descriptors being used
+/intel/rabbitmq/node/{name}/io_read_avg_time | float64 | Avg wall time (ms) for each disk read operation
+/intel/rabbitmq/node/{name}/io_read_avg_time_details/rate | float64 | Rate of wall time for each disk read operation
+/intel/rabbitmq/node/{name}/io_read_bytes | int | Total number of bytes read from disk by the persister
+/intel/rabbitmq/node/{name}/io_read_bytes_details/rate | float64 | Rate of bytes read from disk by the persister
+/intel/rabbitmq/node/{name}/io_read_count | int | Total number of read operations by the persister
+/intel/rabbitmq/node/{name}/io_read_count_details/rate | float64 |  Rate of read operations by the persister
+/intel/rabbitmq/node/{name}/io_seek_avg_time | float64 | Avg wall time (ms) for each seek operation
+/intel/rabbitmq/node/{name}/io_seek_avg_time_details/rate | float64 | Rate of avg wall time (ms) for each seek operation
+/intel/rabbitmq/node/{name}/io_seek_count | int | Total number of seek operations by the persister
+/intel/rabbitmq/node/{name}/io_seek_count_details/rate | float64 | Rate of seek operations by the persister
+/intel/rabbitmq/node/{name}/io_sync_avg_time | float64 | Avg wall time (ms) for each fsync() operation
+/intel/rabbitmq/node/{name}/io_sync_avg_time_details/rate | float64 | Rate of avg wall time (ms) for each fsync() operation
+/intel/rabbitmq/node/{name}/io_sync_count | int | Total number of fsync() operations by the persister
+/intel/rabbitmq/node/{name}/io_sync_count_details/rate | float64 | Rate of fsync() operations by the persister
+/intel/rabbitmq/node/{name}/io_write_avg_time | float64 | Avg wall time (ms) for each disk write operation
+/intel/rabbitmq/node/{name}/io_write_avg_time_details/rate | float64 | Rate of avg wall time (ms) for each disk write operation
+/intel/rabbitmq/node/{name}/io_write_byte | int | Total number of bytes written to disk by the persister
+/intel/rabbitmq/node/{name}/io_write_byte_details/rate | float64 | Rate of bytes written to disk by the persister
+/intel/rabbitmq/node/{name}/io_write_count | int | Total number of write operations by the persister
+/intel/rabbitmq/node/{name}/io_write_count_details/rate | float64 |  Rate of write operations by the persister
+/intel/rabbitmq/node/{name}/mem_used | int | Memory used in bytes
+/intel/rabbitmq/node/{name}/mem_used_details/rate | float64 | Rate of memory used
+/intel/rabbitmq/node/{name}/memory/atom | int | Total memory in use by atom
+/intel/rabbitmq/node/{name}/memory/binary | int | Total binary memory in use
+/intel/rabbitmq/node/{name}/memory/code | int | Total memory in use by code 
+/intel/rabbitmq/node/{name}/memory/connection_channels | int | Total memory in use by connection channels 
+/intel/rabbitmq/node/{name}/memory/connection_other | int | Total memory in use by other connections 
+/intel/rabbitmq/node/{name}/memory/connection_readers | int | Total memory in use by connection readers 
+/intel/rabbitmq/node/{name}/memory/connection_writers | int | Total memory in use by connection writers 
+/intel/rabbitmq/node/{name}/memory/mgmt_db | int | Total memory in use by the Management database 
+/intel/rabbitmq/node/{name}/memory/mnesia | int | Total memory in use by Mnesia database 
+/intel/rabbitmq/node/{name}/memory/msg_index | int | Total memory in use by the message index 
+/intel/rabbitmq/node/{name}/memory/other_ets | int | Total memory in use by other ets 
+/intel/rabbitmq/node/{name}/memory/other_proc | int | Total memory in use by other processes
+/intel/rabbitmq/node/{name}/memory/plugins | int | Total memory in use by plugins 
+/intel/rabbitmq/node/{name}/memory/queue_procs | int | Total memory in use by queue processes
+/intel/rabbitmq/node/{name}/memory/queue_slave_procs | int | Total memory in use by queue processes on slave
+/intel/rabbitmq/node/{name}/memory/total | int | Total memory in use by the node 
+/intel/rabbitmq/node/{name}/mnesia_disk_tx_count | int | Number of Mnesia transactions performed that required writes to disk
+/intel/rabbitmq/node/{name}/mnesia_disk_tx_count_details/rate | float64 | Rate of Mnesia transactions performed that required writes to disk
+/intel/rabbitmq/node/{name}/mnesia_ram_tx_count | int | Number of Mnesia transactions which have been performed that did not require writes to disk
+/intel/rabbitmq/node/{name}/mnesia_ram_tx_count_details/rate | float64 | Rate of Mnesia transactions which have been performed that did not require writes to disk
+/intel/rabbitmq/node/{name}/proc_used | int | Number of Erlang processes in use
+/intel/rabbitmq/node/{name}/proc_used_details/rate | float64 | Rate of Erlang processes in use
+/intel/rabbitmq/node/{name}/queue_index_read_count | int | Number of records read from the queue index
+/intel/rabbitmq/node/{name}/queue_index_read_count_details/rate | float64 | Rate of records read from the queue index
+/intel/rabbitmq/node/{name}/queue_index_write_count | int | Number of records written to the queue index
+/intel/rabbitmq/node/{name}/queue_index_write_count_details/rate | float64 | Rate of records written to the queue index
+/intel/rabbitmq/node/{name}/sockets_used | int | File descriptors used as sockets
+/intel/rabbitmq/node/{name}/sockets_used_details/rate | float64 | Rate of File descriptors used as sockets
+
+####  Exchanges
+
+Namespace | Data Type | Description
+----------|-----------|----------------------
+/intel/rabbitmq/exchanges/{vhost}/{name}/message_stats/confirm | int | Count of messages confirmed
+/intel/rabbitmq/exchanges/{vhost}/{name}/message_stats/publish_in | int | Count of messages published "in" to an exchange (not taking account of routing)
+/intel/rabbitmq/exchanges/{vhost}/{name}/message_stats/publish_out | int | Count of messages published "out" of an exchange (takking account of routing)
+/intel/rabbitmq/exchanges/{vhost}/{name}/message_stats/confirm_details/rate | float64 | Rate at which messages are being confirmed
+/intel/rabbitmq/exchanges/{vhost}/{name}/message_stats/publish_in_details/rate | float64 | Rate of messages published "in" to an exchange
+/intel/rabbitmq/exchanges/{vhost}/{name}/message_stats/publish_out_details/rate | float64 | Rate of  messages published "out" of an exchange
+
+#### Queues
+
+Namespace | Data Type | Description
+----------|-----------|----------------------
+/intel/rabbitmq/queues/{vhost}/{name}/consumers | int | Number of consumers connected to the queue
+/intel/rabbitmq/queues/{vhost}/{name}/disk_reads | int | Number of disk reads made by the queue
+/intel/rabbitmq/queues/{vhost}/{name}/disk_writes | int | Number of disk writes made by the queue
+/intel/rabbitmq/queues/{vhost}/{name}/memory | int | Amount of memory in use by the queue
+/intel/rabbitmq/queues/{vhost}/{name}/message_bytes | int | Total size (in bytes) of messages in the queue
+/intel/rabbitmq/queues/{vhost}/{name}/message_bytes_persistent | int | Total size (in bytes) of messages persisted to disk
+/intel/rabbitmq/queues/{vhost}/{name}/message_bytes_ram | int | Total size (in bytes) of messages in ram
+/intel/rabbitmq/queues/{vhost}/{name}/message_bytes_ready | int | Total size (in bytes) of messages in the queue that are ready
+/intel/rabbitmq/queues/{vhost}/{name}/message_bytes_unacknowledged | int | Total size (in bytes) of messages in the queue that are unacknowledged
+/intel/rabbitmq/queues/{vhost}/{name}/message_stats/disk_reads | int | Count of disk reads for the queue
+/intel/rabbitmq/queues/{vhost}/{name}/message_stats/disk_reads_details/rate | float64 | Rate of disk reads for the queue
+/intel/rabbitmq/queues/{vhost}/{name}/message_stats/publish | int | Count of messages published
+/intel/rabbitmq/queues/{vhost}/{name}/message_stats/publish_details/rate | float64 | Rate of messages published
+/intel/rabbitmq/queues/{vhost}/{name}/messages | int | Number of messages in the queue
+/intel/rabbitmq/queues/{vhost}/{name}/messages_details/rate | float64 | Rate of messages in the queue
+/intel/rabbitmq/queues/{vhost}/{name}/messages_persistent | int | Number of messages persisted to disk
+/intel/rabbitmq/queues/{vhost}/{name}/messages_ram | int | Number of messages in ram
+/intel/rabbitmq/queues/{vhost}/{name}/messages_ready | int | Number of messages ready in the queue
+/intel/rabbitmq/queues/{vhost}/{name}/messages_ready_details/rate | float64 | Rate of messages ready in the queue
+/intel/rabbitmq/queues/{vhost}/{name}/messages_ready_ram | int | Number of messages in ram that are ready
+/intel/rabbitmq/queues/{vhost}/{name}/messages_unacknowledged | int | Number of messages unacknowledged in the queue
+/intel/rabbitmq/queues/{vhost}/{name}/messages_unacknowledged_details/rate | float64 | Rate of messages unacknowledged in the queue
+/intel/rabbitmq/queues/{vhost}/{name}/messages_unacknowledged_ram | int | Number of messages in ram that are unacknowledged
+
+#### vhosts
+
+Namespace | Data Type | Description
+----------|-----------|----------------------
+/intel/rabbitmq/vhosts/{name}/messages | int | Sum of all message fields for all queues in vhost
+/intel/rabbitmq/vhosts/{name}/messages_ready | int | Sum of all messages_ready fields for all queues in vhost
+/intel/rabbitmq/vhosts/{name}/messages_acknowledged | int | Sum of all messages_acknowledged fields for all queues in vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/confirm | int | Global count of messages confirmed for vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/deliver_get | int | Global count of messages delivered for vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/get_no_ack | int | Global count of messages delivered in no-acknowledgement mode in response to basic.get across vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/publish | int | Global count of messages published across vhost
+/intel/rabbitmq/vhosts/{name}/messages_details/rate | float64 | Rate of messages for all queues in vhost
+/intel/rabbitmq/vhosts/{name}/messages_ready_details/rate | float64 | Rate of  all messages_ready fields for all queues in vhost
+/intel/rabbitmq/vhosts/{name}/messages_acknowledged_details/rate | float64 | Rate of all messages_acknowledged fields for all queues in vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/confirm_details/rate | float64 | Global rate of messages confirmed for vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/deliver_get_details/rate | float64 | Global rate of messages delivered for vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/get_no_ack_details/rate | float64 | Global rate of messages delivered in no-acknowledgement mode in response to basic.get across vhost
+/intel/rabbitmq/vhosts/{name}/message_stats/publish_details/rate | float64 | Global rate of messages published across vhost
+/intel/rabbitmq/vhosts/{name}/messages_unacknowledged | int | Global count of messages unacknowledged across all queues
+/intel/rabbitmq/vhosts/{name}/messages_unacknowledged_details/rate | float64 | Global rate of messages unacknowledged across all queues
+
+### Examples
+Here is an example task manifest for collecting metrics from a RabbitMQ node or cluster.
+
+```json
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "5s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/rabbitmq/nodes/*/memory/total": {},
+                "/intel/rabbitmq/queues/*/*/messages": {},
+                "/intel/rabbitmq/exchanges/*/*/message_stats/publish_in_details/rate": {},
+                "/intel/rabbitmq/vhosts/*/messages_ready": {}
+            },
+            "config": {
+                "/intel/rabbitmq": {
+                    "url": "http://localhost:15672",
+                    "user": "guest",
+                    "password": "guest"
+                }
+            },
+            "publish": [
+                {
+                    "plugin_name": "influx",
+                    "config": {
+                        "host": "localhost",
+                        "port": 8086,
+                        "database": "snap",
+                        "user": "admin",
+                        "password": "admin"
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+### Roadmap
+There isn't a current roadmap for this plugin, but it is in active development. As we launch this plugin, we do not have any outstanding requirements for the next release. If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-collector-rabbitmq/issues/new) and/or submit a [pull request](https://github.com/intelsdi-x/snap-plugin-collector-rabbitmq/pulls).
+
+## Community Support
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap To reach out to other users, head to the [main framework](https://github.com/intelsdi-x/snap#community-support).
+
+## Contributing
+We love contributions!
+
+There's more than one way to give back, from examples to blogs to code updates. See our recommended process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+[snap](http://github.com:intelsdi-x/snap), along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
+
+## Acknowledgements
+* Author: [@geauxvirtual](https://github.com/geauxvirtual/)
+
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/main.go
+++ b/main.go
@@ -1,0 +1,30 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/intelsdi-x/snap-plugin-collector-rabbitmq/rabbitmq"
+	"github.com/intelsdi-x/snap/control/plugin"
+)
+
+func main() {
+	plugin.Start(rabbitmq.Meta(), rabbitmq.NewRabbitMQCollector(), os.Args[1])
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,36 @@
+//
+// +build unit
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/rabbitmq/client.go
+++ b/rabbitmq/client.go
@@ -1,0 +1,123 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	APINodesEndpoint     = "nodes"
+	APIQueuesEndpoint    = "queues"
+	APIVhostsEndpoint    = "vhosts"
+	APIExchangesEndpoint = "exchanges"
+	DefaultVhost         = "%2f" // The default vhost on a system is just "/" but we use HEX format
+	DefaultPrefix        = "api"
+)
+
+type result map[string]interface{}
+
+type client struct {
+	url      string
+	source   string
+	user     string
+	password string
+	http     *http.Client
+}
+
+// newClient returns a client to the RabbitMQ management REST API
+// specified with the url, user, and password passed into the method.
+func newClient(_url, user, password string) *client {
+	c := &client{
+		url:      joinUrl(_url, DefaultPrefix),
+		user:     user,
+		password: password,
+	}
+	u, err := url.Parse(_url)
+	if err != nil {
+		panic(err)
+	}
+	c.source = splitHost(u.Host)
+	c.http = &http.Client{}
+	return c
+}
+
+// get makes a get request to the RabbitMQ management REST API
+// and returns body of the response as a []byte array
+func (c *client) get(u string) ([]byte, error) {
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.user, c.password)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	default:
+		return b, nil
+	case 401, 404:
+		var e map[string]string
+		err := json.Unmarshal(b, &e)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("Error calling %s. Error: %s Reason: %s", u, e["error"], e["reason"])
+	}
+}
+
+// queryEndpoint makes a get request for the specified query and returns any result received
+// as a result slice. Not all queries returns a slice, but this made it simpler to always return
+// return a slice.
+func (c *client) queryEndpoint(ep ...string) ([]result, error) {
+	if len(ep) == 0 {
+		return nil, fmt.Errorf("Must pass an endpoint to query")
+	}
+	b, err := c.get(joinUrl(c.url, ep...))
+	if err != nil {
+		return nil, err
+	}
+	var r result
+	err = json.Unmarshal(b, &r)
+	if err != nil {
+		if strings.Contains(err.Error(), "cannot unmarshal array") {
+			var r []result
+			err = json.Unmarshal(b, &r)
+			if err != nil {
+				return nil, err
+			}
+			return r, nil
+		}
+		return nil, err
+	}
+	arr := make([]result, 1)
+	arr[0] = r
+	return arr, nil
+}

--- a/rabbitmq/client_integration_test.go
+++ b/rabbitmq/client_integration_test.go
@@ -1,0 +1,166 @@
+//
+// +build integration
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestAPIConnection(t *testing.T) {
+	c := newClient("http://localhost:15672", "guest", "guest")
+	Convey("Testing API nodes endpoint", t, func() {
+		_, e := c.get(joinUrl(c.url, APINodesEndpoint))
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+
+	Convey("Testing API queues endpoint", t, func() {
+		_, e := c.get(joinUrl(c.url, APIQueuesEndpoint))
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+
+	Convey("Testing API queues endpoint for default vhost", t, func() {
+		_, e := c.get(joinUrl(c.url, APIQueuesEndpoint, DefaultVhost))
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+	Convey("Testing API vhosts endpoint", t, func() {
+		_, e := c.get(joinUrl(c.url, APIVhostsEndpoint))
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+
+	Convey("Testing API vhosts endpoint for default vhost", t, func() {
+		_, e := c.get(joinUrl(c.url, APIVhostsEndpoint, DefaultVhost))
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+}
+
+func TestNodesAPI(t *testing.T) {
+	c := newClient("http://localhost:15672", "guest", "guest")
+	nodes, e := c.getNodes()
+	Convey("Get all nodes from RabbitMQ cluster", t, func() {
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+		Convey("should not be empty", func() {
+			So(len(nodes), ShouldBeGreaterThan, 0)
+		})
+	})
+
+	_, e = c.getNode("rabbit@localhost")
+	Convey("Get rabbit@localhost node from RabbitMQ cluster", t, func() {
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+
+	metrics := getNodeMetrics()
+	Convey("Get metrics that are available to be collected from a node", t, func() {
+		Convey("should return an array of metrics with length equal to nodeMetrics length", func() {
+			So(len(metrics), ShouldEqual, len(nodeMetrics))
+		})
+	})
+}
+
+func TestQueuesAPI(t *testing.T) {
+	c := newClient("http://localhost:15672", "guest", "guest")
+	queues, e := c.getQueues()
+	Convey("Get all queues from RabbitMQ cluster", t, func() {
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+		Convey("should not be empty", func() {
+			So(len(queues), ShouldBeGreaterThan, 0)
+		})
+	})
+
+	_, e = c.getQueue("%2f", "snapq")
+	Convey("Get test queue from RabbitMQ cluster", t, func() {
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+
+	metrics := getQueueMetrics()
+	Convey("Get metrics that are available to be collected from a queue", t, func() {
+		Convey("should return an array of metrics with length equal to queueMetrics length", func() {
+			So(len(metrics), ShouldEqual, len(queueMetrics))
+		})
+	})
+}
+
+func TestExchangesAPI(t *testing.T) {
+	c := newClient("http://localhost:15672", "guest", "guest")
+	exchanges, e := c.getExchanges()
+	Convey("Get all exchanges from RabbitMQ cluster", t, func() {
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+		Convey("should not be empty", func() {
+			So(len(exchanges), ShouldBeGreaterThan, 0)
+		})
+	})
+
+	_, e = c.getExchange("%2f", "snap")
+	Convey("Get pulse exchange from RabbitMQ cluster", t, func() {
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+	})
+
+	metrics := getExchangeMetrics()
+	Convey("Get metrics available for an exchange", t, func() {
+		Convey("should return an array with length same as length of exchangeMetrics", func() {
+			So(len(metrics), ShouldEqual, len(exchangeMetrics))
+		})
+	})
+}
+
+func TestVhostsAPI(t *testing.T) {
+	c := newClient("http://localhost:15672", "guest", "guest")
+	vhosts, e := c.getVhosts()
+	Convey("Get all vhosts from RabbitMQ cluster", t, func() {
+		Convey("should not receive an error", func() {
+			So(e, ShouldBeNil)
+		})
+		Convey("should not be empty", func() {
+			So(len(vhosts), ShouldBeGreaterThan, 0)
+		})
+	})
+
+	metrics := getVhostMetrics()
+	Convey("Get metrics available for a vhost", t, func() {
+		Convey("should return an array with length same as length of vhostMetrics", func() {
+			So(len(metrics), ShouldEqual, len(vhostMetrics))
+		})
+	})
+}

--- a/rabbitmq/exchange.go
+++ b/rabbitmq/exchange.go
@@ -1,0 +1,94 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
+)
+
+// exchangeMetrics is a map of available metrics for an exchange
+// with the type for the value returned by the API.
+var exchangeMetrics = map[string]string{
+	"message_stats/confirm":                  "int",
+	"message_stats/confirm_details/rate":     "float64",
+	"message_stats/publish_in":               "int",
+	"message_stats/publish_in_details/rate":  "float64",
+	"message_stats/publish_out":              "int",
+	"message_stats/publish_out_details/rate": "float64",
+}
+
+// getExchanges returns a slice of exchanges names available on the node or cluster.
+// This is a list of all exchanges on the system for all vhosts.
+func (c *client) getExchanges() ([]string, error) {
+	exchanges, err := c.queryEndpoint(APIExchangesEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	exchArr := make([]string, len(exchanges))
+	for i, e := range exchanges {
+		exchArr[i] = e["name"].(string)
+	}
+	return exchArr, nil
+}
+
+// getExchange returns an API result for an exchange for a vhost.
+func (c *client) getExchange(vhost, name string) (result, error) {
+	exchange, err := c.queryEndpoint(APIExchangesEndpoint, vhost, name)
+	if err != nil {
+		return nil, err
+	}
+	return exchange[0], nil
+}
+
+// getExchangesByVhost returns a slice of API results for all exchanges for a specific
+// vhost.
+func (c *client) getExchangesByVhost(vhost string) ([]result, error) {
+	exchanges, err := c.queryEndpoint(APIExchangesEndpoint, vhost)
+	if err != nil {
+		return nil, err
+	}
+	return exchanges, nil
+}
+
+// getExchangeMetrics returns a slice of plugin.PluginMetricType created from
+// the map of available metrics for an exchange.
+func getExchangeMetrics() []plugin.PluginMetricType {
+	var mts []plugin.PluginMetricType
+	ns := []string{"intel", "rabbitmq", "exchanges", "*", "*"}
+	for k := range exchangeMetrics {
+		mts = append(mts, plugin.PluginMetricType{
+			Namespace_: generateNamespace(ns, k),
+			Labels_:    exchangeLabels(),
+		})
+	}
+	return mts
+}
+
+func exchangeLabels() []core.Label {
+	return []core.Label{
+		{
+			Index: 3,
+			Name:  "vhost",
+		},
+		{
+			Index: 4,
+			Name:  "exchange",
+		}}
+}

--- a/rabbitmq/node.go
+++ b/rabbitmq/node.go
@@ -1,0 +1,133 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"fmt"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
+)
+
+// nodeMetrics is a map of metrics available to be collected per
+// node along type of value that is returned.
+var nodeMetrics = map[string]string{
+	"disk_free":                            "int",
+	"disk_free_details/rate":               "float64",
+	"fd_used":                              "int",
+	"fd_used_details/rate":                 "float64",
+	"io_read_avg_time":                     "float64",
+	"io_read_avg_time_details/rate":        "float64",
+	"io_read_bytes":                        "int",
+	"io_read_bytes_details/rate":           "float64",
+	"io_read_count":                        "int",
+	"io_read_count_details/rate":           "float64",
+	"io_seek_avg_time":                     "float64",
+	"io_seek_avg_time_details/rate":        "float64",
+	"io_seek_count":                        "int",
+	"io_seek_count_details/rate":           "float64",
+	"io_sync_avg_time":                     "float64",
+	"io_sync_avg_time_details/rate":        "float64",
+	"io_sync_count":                        "int",
+	"io_sync_count_details/rate":           "float64",
+	"io_write_avg_time":                    "float64",
+	"io_write_avg_time_details/rate":       "float64",
+	"io_write_bytes":                       "int",
+	"io_write_bytes_details/rate":          "float64",
+	"io_write_count":                       "int",
+	"io_write_count_details/rate":          "float64",
+	"mem_used":                             "int",
+	"mem_used_details/rate":                "float64",
+	"memory/atom":                          "int",
+	"memory/binary":                        "int",
+	"memory/code":                          "int",
+	"memory/connection_channels":           "int",
+	"memory/connection_other":              "int",
+	"memory/connection_readers":            "int",
+	"memory/connection_writers":            "int",
+	"memory/mgmt_db":                       "int",
+	"memory/mnesia":                        "int",
+	"memory/msg_index":                     "int",
+	"memory/other_ets":                     "int",
+	"memory/other_proc":                    "int",
+	"memory/other_system":                  "int",
+	"memory/plugins":                       "int",
+	"memory/queue_procs":                   "int",
+	"memory/queue_slave_procs":             "int",
+	"memory/total":                         "int",
+	"mnesia_disk_tx_count":                 "int",
+	"mnesia_disk_tx_count_details/rate":    "float64",
+	"mnesia_ram_tx_count":                  "int",
+	"mnesia_ram_tx_count_details/rate":     "float64",
+	"proc_used":                            "int",
+	"proc_used_details/rate":               "float64",
+	"queue_index_read_count":               "int",
+	"queue_index_read_count_details/rate":  "float64",
+	"queue_index_write_count":              "int",
+	"queue_index_write_count_details/rate": "float64",
+	"sockets_used":                         "int",
+	"sockets_used_details/rate":            "float64",
+}
+
+// getNodes returns a slice of node names available from the node or cluster
+func (c *client) getNodes() ([]string, error) {
+	nodes, err := c.queryEndpoint(APINodesEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	nodeArr := make([]string, len(nodes))
+	for i, e := range nodes {
+		nodeArr[i] = e["name"].(string)
+	}
+	return nodeArr, nil
+}
+
+// getNode returns the API result for a single node. The API request is made
+// with '?memory=true' to return all memory metrics for the node as well
+func (c *client) getNode(name string) (result, error) {
+	node, err := c.queryEndpoint(APINodesEndpoint, name+"?memory=true")
+	if err != nil {
+		return nil, err
+	}
+	if len(node) > 1 {
+		return nil, fmt.Errorf("Error: more than one result returned")
+	}
+	return node[0], nil
+}
+
+// getNodeMetrics returns a slice of available plugin.PluginMetricTypes created
+// from the nodeMetrics map
+func getNodeMetrics() []plugin.PluginMetricType {
+	var mts []plugin.PluginMetricType
+	ns := []string{"intel", "rabbitmq", "nodes", "*"}
+	for k := range nodeMetrics {
+		mts = append(mts, plugin.PluginMetricType{
+			Namespace_: generateNamespace(ns, k),
+			Labels_:    nodeLabels(),
+		})
+	}
+	return mts
+}
+
+func nodeLabels() []core.Label {
+	return []core.Label{{
+		Index: 3,
+		Name:  "node",
+	}}
+}

--- a/rabbitmq/queue.go
+++ b/rabbitmq/queue.go
@@ -1,0 +1,111 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
+)
+
+// queueMetrics is a map of available metrics for a queue with the type
+// of the value returned by the API.
+var queueMetrics = map[string]string{
+	"consumers":                             "int",
+	"disk_reads":                            "int",
+	"disk_writes":                           "int",
+	"memory":                                "int",
+	"message_bytes":                         "int",
+	"message_bytes_persistent":              "int",
+	"message_bytes_ram":                     "int",
+	"message_bytes_ready":                   "int",
+	"message_bytes_unacknowledged":          "int",
+	"message_stats/disk_reads":              "int",
+	"message_stats/disk_reads_details/rate": "float64",
+	"message_stats/publish":                 "int",
+	"message_stats/publish_details/rate":    "float64",
+	"messages":                              "int",
+	"messages_details/rate":                 "float64",
+	"messages_persistent":                   "int",
+	"messages_ram":                          "int",
+	"messages_ready":                        "int",
+	"messages_ready_details/rate":           "float64",
+	"messages_ready_ram":                    "int",
+	"messages_unacknowledged":               "int",
+	"messages_unacknowledged_details/rate":  "float64",
+	"messages_unacknowledged_ram":           "int",
+}
+
+// getQueues returns a slice of named queues available on the node or cluster
+// that includes all queues for all vhosts.
+func (c *client) getQueues() ([]string, error) {
+	queues, err := c.queryEndpoint(APIQueuesEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	qArr := make([]string, len(queues))
+	for i, e := range queues {
+		qArr[i] = e["name"].(string)
+	}
+	return qArr, nil
+}
+
+// getQueue returns the API result for a single queue in a single vhost.
+func (c *client) getQueue(vhost, name string) (result, error) {
+	queue, err := c.queryEndpoint(APIQueuesEndpoint, vhost, name)
+	if err != nil {
+		return nil, err
+	}
+	return queue[0], nil
+}
+
+// getQueuesByVhost returns a slice of results of all queues for the specified
+// vhost.
+func (c *client) getQueuesByVhost(vhost string) ([]result, error) {
+	queues, err := c.queryEndpoint(APIQueuesEndpoint, vhost)
+	if err != nil {
+		return nil, err
+	}
+	return queues, nil
+}
+
+// getQueueMetrics returns a slice of plugin.PluginMetricTypes made from the
+// map of available metrics for a queue.
+func getQueueMetrics() []plugin.PluginMetricType {
+	var mts []plugin.PluginMetricType
+	ns := []string{"intel", "rabbitmq", "queues", "*", "*"}
+	for k := range queueMetrics {
+		mts = append(mts, plugin.PluginMetricType{
+			Namespace_: generateNamespace(ns, k),
+			Labels_:    queueLabels(),
+		})
+	}
+	return mts
+}
+
+func queueLabels() []core.Label {
+	return []core.Label{
+		{
+			Index: 3,
+			Name:  "vhost",
+		},
+		{
+			Index: 4,
+			Name:  "queue",
+		}}
+}

--- a/rabbitmq/rabbitmq.go
+++ b/rabbitmq/rabbitmq.go
@@ -1,0 +1,488 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+	"github.com/intelsdi-x/snap/core/ctypes"
+)
+
+const (
+	name       = "rabbitmq-collector"
+	version    = 1
+	pluginType = plugin.CollectorPluginType
+)
+
+// Meta returns required plugin meta details to the snap daemon. This includes
+// the name, version, and type of plugin along with what content encoding (GOB or JSONRPC)
+// should be used for communication between the plugin and the snap daemon.
+func Meta() *plugin.PluginMeta {
+	return plugin.NewPluginMeta(name, version, pluginType, []string{plugin.SnapGOBContentType}, []string{plugin.SnapGOBContentType})
+}
+
+type rabbitMQCollector struct {
+	client *client
+}
+
+// NewRabbitMQCollector returns a pointer to an instance of the rabbitMQCollector
+// that will be used to call functions the instance supports
+func NewRabbitMQCollector() *rabbitMQCollector {
+	return &rabbitMQCollector{}
+}
+
+// GetConfigPolicy returns the config policy required for collecting metrics
+// from this plugin. In order to collect metrics, the plugin needs to know
+// the RabbitMQ host to collect from and the credentials (user and password) for
+// communicating the API of the RabbitMQ server.
+//
+// Note: For remote instances of RabbitMQ, the credentials of guest/guest are disabled
+// by the RabbitMQ server config.
+func (r *rabbitMQCollector) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	c := cpolicy.New()
+	rule, _ := cpolicy.NewStringRule("url", false, "http://localhost:15672")
+	rule2, _ := cpolicy.NewStringRule("user", false, "guest")
+	rule3, _ := cpolicy.NewStringRule("password", false, "guest")
+	config := cpolicy.NewPolicyNode()
+	config.Add(rule, rule2, rule3)
+	c.Add([]string{""}, config)
+	return c, nil
+}
+
+// GetMetricTypes returns the metrics available to be collected from this plugin. The available metrics
+// are broken down between nodes, exchanges, queues, and vhosts. For a full list of available
+// metrics, please see the README or the other source files pertaining to those topics.
+func (r *rabbitMQCollector) GetMetricTypes(_ plugin.PluginConfigType) ([]plugin.PluginMetricType, error) {
+	mts := []plugin.PluginMetricType{}
+
+	mts = append(mts, getNodeMetrics()...)
+	mts = append(mts, getExchangeMetrics()...)
+	mts = append(mts, getVhostMetrics()...)
+	mts = append(mts, getQueueMetrics()...)
+
+	return mts, nil
+}
+
+// CollectMetrics takes a list of metrics from the snap daemon, collects the metrics from the required
+// hosts and returns the collected metrics to the snap daemon.
+func (r *rabbitMQCollector) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	// Cache nodes, vhosts to reduce API calls on a collection
+	// Exchanges and queues are multi level by vhost. Map may better serve them.
+	var nodes []string
+	var vhosts []string
+
+	// Cache API results
+	var nodeResCache map[string]result
+	var exchResCache map[string]result
+	var queueResCache map[string]result
+	var vhostResCache map[string]result
+	var metrics []plugin.PluginMetricType
+
+	timestamp := time.Now()
+	for _, mt := range mts {
+		var err error
+		if r.client == nil {
+			if err := r.init(mt.Config().Table()); err != nil {
+				return nil, err
+			}
+		}
+		ns := mt.Namespace()
+		metType := ns[2]
+		switch metType {
+		default:
+			return nil, fmt.Errorf("Unknown type, %s, for requested metric", metType)
+		case "nodes":
+			// Let's first verify the metric given is part of our available metrics
+			metric := ns[4:]
+			metStr := metricString(metric)
+			if _, ok := nodeMetrics[metStr]; !ok {
+				return nil, fmt.Errorf("Unsupported node metric: %s", metStr)
+			}
+			node := ns[3]
+
+			// Check for wildcard to see if we are collecting for a single node or all nodes
+			// A cache is used so that additional node metrics that be collected on a single pass
+			// will not result in multiple API calls
+			if node == "*" {
+				if len(nodes) == 0 {
+					nodes, err = r.client.getNodes()
+					if err != nil {
+						return nil, err
+					}
+				}
+				for _, n := range nodes {
+					if _, ok := nodeResCache[n]; !ok {
+						res, err := r.client.getNode(n)
+						if err != nil {
+							return nil, err
+						}
+						nodeResCache = map[string]result{
+							n: res,
+						}
+					}
+					if v, err := walkResult(nodeResCache[n], metric); err == nil {
+						ns_ := copyNamespace(ns)
+						ns_[3] = n
+						metrics = append(metrics, plugin.PluginMetricType{
+							Namespace_: ns_,
+							Source_:    r.client.source,
+							Data_:      typeValue(nodeMetrics[metStr], v),
+							Timestamp_: timestamp,
+							Labels_:    nodeLabels(), // Labels are not passed back with metric
+						})
+					}
+				}
+			} else {
+				if _, ok := nodeResCache[node]; !ok {
+					res, err := r.client.getNode(node)
+					if err != nil {
+						return nil, err
+					}
+					nodeResCache = map[string]result{
+						node: res,
+					}
+				}
+				v, err := walkResult(nodeResCache[node], metric)
+				if err != nil {
+					return nil, err
+				}
+				metrics = append(metrics, plugin.PluginMetricType{
+					Namespace_: ns,
+					Source_:    r.client.source,
+					Data_:      typeValue(nodeMetrics[metStr], v),
+					Timestamp_: timestamp,
+					Labels_:    nodeLabels(),
+				})
+
+			}
+		case "exchanges":
+			metric := ns[5:]
+			metStr := metricString(metric)
+			if _, ok := exchangeMetrics[metStr]; !ok {
+				return nil, fmt.Errorf("Unsupported exchange metric: %s", metStr)
+			}
+
+			vhost := ns[3]
+			exchange := ns[4]
+
+			if vhost == "*" {
+				if len(vhosts) == 0 {
+					vhosts, err = r.client.getVhosts()
+					if err != nil {
+						return nil, err
+					}
+				}
+				if exchange == "*" {
+					for _, vh := range vhosts {
+						exchanges, err := r.client.getExchangesByVhost(vh)
+						if err != nil {
+							return nil, err
+						}
+						// Need an error check here as default exchange is "", which is a bit idiotic for pulling stats
+						// and a filter to filter out all default amq. exchanges when a vhost is created.
+						for _, exch := range exchanges {
+							if exch["name"] == "" || strings.Contains(exch["name"].(string), "amq.") {
+								continue
+							}
+							key := createKey(vh, exch["name"].(string))
+							if _, ok := exchResCache[key]; !ok {
+								res, err := r.client.getExchange(vh, exch["name"].(string))
+								if err != nil {
+									return nil, err
+								}
+								exchResCache = map[string]result{
+									key: res,
+								}
+							}
+							if v, err := walkResult(exchResCache[key], metric); err == nil {
+								ns_ := copyNamespace(ns)
+								ns_[3] = vh
+								ns_[4] = exch["name"].(string)
+								metrics = append(metrics, plugin.PluginMetricType{
+									Namespace_: ns_,
+									Source_:    r.client.source,
+									Data_:      typeValue(exchangeMetrics[metStr], v),
+									Timestamp_: timestamp,
+									Labels_:    exchangeLabels(),
+								})
+							}
+						}
+					}
+				} else {
+					return nil, fmt.Errorf("We do not currently .../exchanges/*/<some name>/<some metric>")
+				}
+
+			} else {
+				if exchange == "*" {
+					// need a better to cache these results as they are vhost:exchange
+					exchanges, err := r.client.getExchangesByVhost(vhost)
+					if err != nil {
+						return nil, err
+					}
+					for _, exch := range exchanges {
+						if exch["name"] == "" || strings.Contains(exch["name"].(string), "amq.") {
+							continue
+						}
+						key := createKey(vhost, exch["name"].(string))
+						if _, ok := exchResCache[key]; !ok {
+							res, err := r.client.getExchange(vhost, exch["name"].(string))
+							if err != nil {
+								return nil, err
+							}
+							exchResCache = map[string]result{
+								key: res,
+							}
+						}
+						if v, err := walkResult(exchResCache[key], metric); err == nil {
+							ns_ := copyNamespace(ns)
+							ns_[4] = exch["name"].(string)
+							metrics = append(metrics, plugin.PluginMetricType{
+								Namespace_: ns_,
+								Source_:    r.client.source,
+								Data_:      typeValue(exchangeMetrics[metStr], v),
+								Timestamp_: timestamp,
+								Labels_:    exchangeLabels(),
+							})
+						}
+					}
+				} else {
+					key := createKey(vhost, exchange)
+					if _, ok := exchResCache[key]; !ok {
+						res, err := r.client.getExchange(vhost, exchange)
+						if err != nil {
+							return nil, err
+						}
+						exchResCache = map[string]result{
+							key: res,
+						}
+					}
+					v, err := walkResult(exchResCache[key], metric)
+					if err != nil {
+						return nil, err
+					}
+					metrics = append(metrics, plugin.PluginMetricType{
+						Namespace_: ns,
+						Source_:    r.client.source,
+						Data_:      typeValue(exchangeMetrics[metStr], v),
+						Timestamp_: timestamp,
+						Labels_:    exchangeLabels(),
+					})
+				}
+			}
+		case "queues":
+			metric := ns[5:]
+			metStr := metricString(metric)
+			if _, ok := queueMetrics[metStr]; !ok {
+				return nil, fmt.Errorf("Unsupported queue metric: %s", metStr)
+			}
+
+			vhost := ns[3]
+			queue := ns[4]
+
+			if vhost == "*" {
+				if len(vhosts) == 0 {
+					vhosts, err = r.client.getVhosts()
+					if err != nil {
+						return nil, err
+					}
+				}
+				if queue == "*" {
+					for _, vh := range vhosts {
+						queues, err := r.client.getQueuesByVhost(vh)
+						if err != nil {
+							return nil, err
+						}
+						for _, q := range queues {
+							key := createKey(vh, q["name"].(string))
+							if _, ok := queueResCache[key]; !ok {
+								res, err := r.client.getQueue(vh, q["name"].(string))
+								if err != nil {
+									return nil, err
+								}
+								queueResCache = map[string]result{
+									key: res,
+								}
+							}
+							if v, err := walkResult(queueResCache[key], metric); err == nil {
+								ns_ := copyNamespace(ns)
+								ns_[3] = vh
+								ns_[4] = q["name"].(string)
+								metrics = append(metrics, plugin.PluginMetricType{
+									Namespace_: ns_,
+									Source_:    r.client.source,
+									Data_:      typeValue(queueMetrics[metStr], v),
+									Timestamp_: timestamp,
+									Labels_:    queueLabels(),
+								})
+							}
+						}
+					}
+				} else {
+					return nil, fmt.Errorf("We do not currently .../queues/*/<some name>/<some metric>")
+				}
+
+			} else {
+				if queue == "*" {
+					// need a better to cache these results as they are vhost:exchange
+					queues, err := r.client.getQueuesByVhost(vhost)
+					if err != nil {
+						return nil, err
+					}
+					for _, q := range queues {
+						key := createKey(vhost, q["name"].(string))
+						if _, ok := queueResCache[key]; !ok {
+							res, err := r.client.getQueue(vhost, q["name"].(string))
+							if err != nil {
+								return nil, err
+							}
+							queueResCache = map[string]result{
+								key: res,
+							}
+						}
+						if v, err := walkResult(queueResCache[key], metric); err == nil {
+							ns_ := copyNamespace(ns)
+							ns_[4] = q["name"].(string)
+							metrics = append(metrics, plugin.PluginMetricType{
+								Namespace_: ns_,
+								Source_:    r.client.source,
+								Data_:      typeValue(queueMetrics[metStr], v),
+								Timestamp_: timestamp,
+								Labels_:    queueLabels(),
+							})
+						}
+					}
+				} else {
+					key := createKey(vhost, queue)
+					if _, ok := queueResCache[key]; !ok {
+						res, err := r.client.getQueue(vhost, queue)
+						if err != nil {
+							return nil, err
+						}
+						queueResCache = map[string]result{
+							key: res,
+						}
+					}
+					v, err := walkResult(queueResCache[key], metric)
+					if err != nil {
+						return nil, err
+					}
+					metrics = append(metrics, plugin.PluginMetricType{
+						Namespace_: ns,
+						Source_:    r.client.source,
+						Data_:      typeValue(queueMetrics[metStr], v),
+						Timestamp_: timestamp,
+						Labels_:    queueLabels(),
+					})
+				}
+			}
+		case "vhosts":
+			// Let's first verify the metric given is part of our available metrics
+			metric := ns[4:]
+			metStr := metricString(metric)
+			if _, ok := vhostMetrics[metStr]; !ok {
+				return nil, fmt.Errorf("Unsupported node metric: %s", metStr)
+			}
+			vhost := ns[3]
+
+			// Check for wildcard to see if we are collecting for a single node or all nodes
+			// A cache is used so that additional node metrics that be collected on a single pass
+			// will not result in multiple API calls
+			if vhost == "*" {
+				if len(vhosts) == 0 {
+					vhosts, err = r.client.getVhosts()
+					if err != nil {
+						return nil, err
+					}
+				}
+				for _, vh := range vhosts {
+					if _, ok := vhostResCache[vh]; !ok {
+						res, err := r.client.getVhost(vh)
+						if err != nil {
+							return nil, err
+						}
+						vhostResCache = map[string]result{
+							vh: res,
+						}
+					}
+					if v, err := walkResult(vhostResCache[vh], metric); err == nil {
+						ns_ := copyNamespace(ns)
+						ns_[3] = vh
+						metrics = append(metrics, plugin.PluginMetricType{
+							Namespace_: ns_,
+							Source_:    r.client.source,
+							Data_:      typeValue(vhostMetrics[metStr], v),
+							Timestamp_: timestamp,
+							Labels_:    vhostLabels(),
+						})
+					}
+				}
+			} else {
+				if _, ok := vhostResCache[vhost]; !ok {
+					res, err := r.client.getVhost(vhost)
+					if err != nil {
+						return nil, err
+					}
+					vhostResCache = map[string]result{
+						vhost: res,
+					}
+				}
+				v, err := walkResult(vhostResCache[vhost], metric)
+				if err != nil {
+					return nil, err
+				}
+				metrics = append(metrics, plugin.PluginMetricType{
+					Namespace_: ns,
+					Source_:    r.client.source,
+					Data_:      typeValue(vhostMetrics[metStr], v),
+					Timestamp_: timestamp,
+					Labels_:    vhostLabels(),
+				})
+
+			}
+		}
+
+	}
+
+	return metrics, nil
+}
+
+func (r *rabbitMQCollector) init(cfg map[string]ctypes.ConfigValue) error {
+	if _, ok := cfg["url"]; !ok {
+		return fmt.Errorf("Plugin config must contain url for RabbitMQ instance to connect to")
+	}
+
+	if _, ok := cfg["user"]; !ok {
+		return fmt.Errorf("Plugin config must contain user for accessing RabbitMQ instance")
+	}
+
+	if _, ok := cfg["password"]; !ok {
+		return fmt.Errorf("Plugin config must contain password for accessing RabbitMQ instance")
+	}
+
+	r.client = newClient(
+		cfg["url"].(ctypes.ConfigValueStr).Value,
+		cfg["user"].(ctypes.ConfigValueStr).Value,
+		cfg["password"].(ctypes.ConfigValueStr).Value,
+	)
+	return nil
+}

--- a/rabbitmq/rabbitmq_integration_test.go
+++ b/rabbitmq/rabbitmq_integration_test.go
@@ -1,0 +1,299 @@
+//
+// +build integration
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core/ctypes"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/streadway/amqp"
+)
+
+func TestRabbitMQCollectMetrics(t *testing.T) {
+	// Connect to RabbitMQ
+	c, err := NewConsumer(
+		"localhost:5672",
+		"snap",
+		"fanout",
+		"snapq",
+		"metrics",
+		"conTag",
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	for i := 0; i < 5; i++ {
+		err := publishAmqp(
+			"localhost:5672",
+			"snap",
+			"fanout",
+			"metrics",
+			"test"+string(i),
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	if err := c.Shutdown(); err != nil {
+		panic(err)
+	}
+
+	cfg := plugin.NewPluginConfigType()
+	cfg.ConfigDataNode.AddItem("url", ctypes.ConfigValueStr{Value: "http://localhost:15672"})
+	cfg.ConfigDataNode.AddItem("user", ctypes.ConfigValueStr{Value: "guest"})
+	cfg.ConfigDataNode.AddItem("password", ctypes.ConfigValueStr{Value: "guest"})
+
+	r := &rabbitMQCollector{}
+
+	mts := []plugin.PluginMetricType{
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "nodes", "rabbit@localhost", "disk_free"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "nodes", "rabbit@localhost", "memory", "total"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "nodes", "*", "sockets_used"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "nodes", "*", "memory", "mnesia"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "vhosts", "%2f", "message_stats", "deliver_get"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "vhosts", "*", "messages"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "vhosts", "*", "messages_details", "rate"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "exchanges", "*", "*", "message_stats", "publish_in_details", "rate"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "exchanges", "%2f", "snap", "message_stats", "publish_in"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "exchanges", "%2f", "*", "message_stats", "publish_out"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "exchanges", "*", "*", "message_stats", "confirm"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "queues", "%2f", "snapq", "messages_unacknowledged"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "queues", "%2f", "snapq", "messages_details", "rate"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "queues", "%2f", "*", "message_stats", "publish"},
+		},
+		plugin.PluginMetricType{
+			Config_:    cfg.ConfigDataNode,
+			Namespace_: []string{"intel", "rabbitmq", "queues", "*", "*", "messages"},
+		},
+	}
+	metrics, err := r.CollectMetrics(mts)
+	Convey("Collecting metrics from RabbitMQ node or cluster", t, func() {
+		Convey("Should not return an error", func() {
+			So(err, ShouldBeNil)
+		})
+		Convey("And metrics collected should be greater than 0", func() {
+			So(len(metrics), ShouldBeGreaterThan, 0)
+		})
+	})
+}
+
+// We need to connect to Rabbitmq instance and send and receive messages so we can
+// make sure the api has the available metrics to return
+
+type Consumer struct {
+	connection *amqp.Connection
+	channel    *amqp.Channel
+	tag        string
+	quit       chan error
+}
+
+func NewConsumer(host, exchange, exchangeType, queueName, key, tag string) (*Consumer, error) {
+	c := &Consumer{
+		connection: nil,
+		channel:    nil,
+		tag:        tag,
+		quit:       make(chan error),
+	}
+
+	var err error
+
+	c.connection, err = amqp.Dial("amqp://" + host)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-c.connection.NotifyClose(make(chan *amqp.Error))
+	}()
+
+	c.channel, err = c.connection.Channel()
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.channel.ExchangeDeclare(
+		exchange,     // name of the exchange
+		exchangeType, // type of exchange
+		true,         // durable
+		false,        // delete when complete
+		false,        // internal
+		false,        // noWait
+		nil,          //arguments
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	queue, err := c.channel.QueueDeclare(
+		queueName, // name of the queue
+		true,      // durable
+		false,     //delete when complete
+		false,     //exclusive
+		false,     //noWait
+		nil,       //arguments
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.channel.QueueBind(
+		queue.Name, // name of the queue
+		key,        // bindingKey
+		exchange,   // exchange
+		false,      // noWait
+		nil,        // arguments
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := c.channel.Consume(
+		queue.Name, // name of the queue
+		c.tag,      // We don't care about a tag for this
+		true,       // auto-ack messages
+		false,      // exclusive
+		false,      // noLocal
+		false,      // noWait
+		nil,        // arguments
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	go receive(msgs, c.quit)
+
+	return c, nil
+}
+
+func (c *Consumer) Shutdown() error {
+	if err := c.channel.Cancel(c.tag, true); err != nil {
+		return err
+	}
+
+	if err := c.connection.Close(); err != nil {
+		return err
+	}
+
+	return <-c.quit
+}
+
+func receive(msgs <-chan amqp.Delivery, quit chan error) {
+	for m := range msgs {
+		fmt.Println(string(m.Body))
+	}
+	quit <- nil
+}
+
+func publishAmqp(host, exchange, exchangeType, routingKey, body string) error {
+	connection, err := amqp.Dial("amqp://" + host)
+	if err != nil {
+		return err
+	}
+
+	defer connection.Close()
+
+	channel, err := connection.Channel()
+	if err != nil {
+		return err
+	}
+
+	err = channel.ExchangeDeclare(
+		exchange,     // name of exchange
+		exchangeType, // type of exchange
+		true,         // durable
+		false,        // auto-delete
+		false,        //internal
+		false,        //noWait
+		nil,          // arguments
+	)
+	if err != nil {
+		return err
+	}
+
+	err = channel.Publish(
+		exchange,   // name of exchange
+		routingKey, // routing to queue
+		false,      // mandatory
+		false,      // immediate
+		amqp.Publishing{
+			Headers:         amqp.Table{},
+			ContentType:     "text/plain",
+			ContentEncoding: "",
+			Body:            []byte(body),
+			DeliveryMode:    amqp.Transient,
+			Priority:        0,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/rabbitmq/rabbitmq_test.go
+++ b/rabbitmq/rabbitmq_test.go
@@ -1,0 +1,43 @@
+//
+// +build unit
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"testing"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRabbitMQGetMetricTypes(t *testing.T) {
+	r := &rabbitMQCollector{}
+	cfg := plugin.NewPluginConfigType()
+	mts, err := r.GetMetricTypes(cfg)
+	Convey("Getting metric types", t, func() {
+		Convey("should not error", func() {
+			So(err, ShouldBeNil)
+		})
+		Convey("should return a list of metrics greater than 0", func() {
+			So(len(mts), ShouldBeGreaterThan, 0)
+		})
+	})
+}

--- a/rabbitmq/utils.go
+++ b/rabbitmq/utils.go
@@ -1,0 +1,95 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"fmt"
+	"strings"
+)
+
+// joinUrl will take a url and an array of endpoints and join
+// them with a '/' and return the resulting string
+func joinUrl(url string, endpoint ...string) string {
+	p := url
+	for _, e := range endpoint {
+		p += "/" + e
+	}
+	return p
+}
+
+// metricString is used to join a metric for lookup in a metric
+// list or cache
+func metricString(ns []string) string {
+	return strings.Join(ns, "/")
+}
+
+// createKey returns a string of two strings joined by ':'
+// Used as a key for cache
+func createKey(a, b string) string {
+	return a + ":" + b
+}
+
+// walkResult walks through a result returned from the API and returns
+// the value to the metric requested
+func walkResult(res result, keys []string) (interface{}, error) {
+	if len(keys) == 1 {
+		if val, ok := res[keys[0]]; ok {
+			return val, nil
+		}
+	} else {
+		if val, ok := res[keys[0]]; ok {
+			if v, ok := (val).(map[string]interface{}); ok {
+				return walkResult(v, keys[1:])
+			}
+		}
+	}
+	return nil, fmt.Errorf("Metric not found")
+}
+
+// typeValue returns the correct type for a value returned by the API
+func typeValue(valueType string, value interface{}) interface{} {
+	switch valueType {
+	default:
+		return 0
+	case "int":
+		return int(value.(float64))
+	case "float64":
+		return value.(float64)
+	}
+}
+
+// generateNamespace is used to append a metric a namespace and return
+// the entire namespace to be returned with a metric.
+func generateNamespace(ns []string, metric string) []string {
+	return append(ns, strings.Split(metric, "/")...)
+}
+
+// splitHost takes a url.Host string and splits the string into the host
+// and port, returning just the host portion
+func splitHost(host string) string {
+	return strings.Split(host, ":")[0]
+}
+
+// copyNamespace copies the namespace provided to a new slice
+// and returns it
+func copyNamespace(src []string) []string {
+	dst := make([]string, len(src))
+	copy(dst, src)
+	return dst
+}

--- a/rabbitmq/vhost.go
+++ b/rabbitmq/vhost.go
@@ -1,0 +1,92 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
+)
+
+// vhostMetrics is a map of available metrics for each vhost on the node
+// or cluster with the value type returned by the API for the metric.
+var vhostMetrics = map[string]string{
+	"messages":                               "int",
+	"messages_details/rate":                  "float64",
+	"messages_acknowledged":                  "int",
+	"messages_acknowledged_details/rate":     "float64",
+	"messages_ready":                         "int",
+	"messages_ready_details/rate":            "float64",
+	"messages_unacknowledged":                "int",
+	"messages_unacknowledged_details/rate":   "float64",
+	"message_stats/confirm":                  "int",
+	"message_stats/confirm_details/rate":     "float64",
+	"message_stats/deliver_get":              "int",
+	"message_stats/deliver_get_details/rate": "float64",
+	"message_stats/get_no_ack":               "int",
+	"message_stats/get_no_ack_details/rate":  "float64",
+	"message_stats/publish":                  "int",
+	"message_stats/publish_details/rate":     "float64",
+}
+
+// getVhosts returns a slice of available vhost names on the node or cluster
+func (c *client) getVhosts() ([]string, error) {
+	vhosts, err := c.queryEndpoint(APIVhostsEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	vArr := make([]string, len(vhosts))
+	for i, e := range vhosts {
+		if e["name"] == "/" {
+			vArr[i] = DefaultVhost
+			continue
+		}
+		vArr[i] = e["name"].(string)
+	}
+	return vArr, nil
+}
+
+// getVhost returns the API result for a single vhost
+func (c *client) getVhost(name string) (result, error) {
+	vhost, err := c.queryEndpoint(APIVhostsEndpoint, name)
+	if err != nil {
+		return nil, err
+	}
+	return vhost[0], nil
+}
+
+// getVhostMetrics returns a slice of plugin.PluginMetricType that is
+// created from the available metrics in the vhostMetrics map.
+func getVhostMetrics() []plugin.PluginMetricType {
+	var mts []plugin.PluginMetricType
+	ns := []string{"intel", "rabbitmq", "vhosts", "*"}
+	for k := range vhostMetrics {
+		mts = append(mts, plugin.PluginMetricType{
+			Namespace_: generateNamespace(ns, k),
+			Labels_:    vhostLabels(),
+		})
+	}
+	return mts
+}
+
+func vhostLabels() []core.Label {
+	return []core.Label{{
+		Index: 3,
+		Name:  "vhost",
+	}}
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "snap-plugin-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Snap Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Snap Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/vet
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get golang.org/x/tools/cmd/cover
+	
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go rabbitmq/"
+	VET_DIRS=". ./rabbitmq/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+ 
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+ 
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+ 
+	go tool cover -func profile.cov
+ 
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+elif [[ $TEST_SUITE == "integration" ]]; then
+	cd $SNAP_PLUGIN_SOURCE
+	go test -v --tags=integration ./...
+fi


### PR DESCRIPTION
The RabbitMQ Collect Plugin collects metrics from a RabbitMQ node or cluster for nodes, vhosts, exchanges, and queues. The current version of the plugin (1) provides the capability to collect 100 metrics from a RabbitMQ system provided the system returns the metric from the API. Due to the way the API works, while the plugin may make a metric available, the metric may not be technically available from the system for number of reasons due to the results retuned from the API.

For instance, if a new vhost is created, no metrics will be returned for that vhost until exchanges and queues are also created in that vhost. 
