### PR TITLE
Download dependency before running integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ services:
 - rabbitmq
 language: go
 go:
-- 1.5.3
-- 1.6.2
+- 1.5.4
+- 1.6.3
 before_install:
 - go get github.com/tools/godep
 - if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x

--- a/rabbitmq/rabbitmq_integration_test.go
+++ b/rabbitmq/rabbitmq_integration_test.go
@@ -70,64 +70,64 @@ func TestRabbitMQCollectMetrics(t *testing.T) {
 
 	r := &rabbitMQCollector{}
 
-	mts := []plugin.PluginMetricType{
-		plugin.PluginMetricType{
+	mts := []plugin.MetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "nodes", "rabbit@localhost", "disk_free"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "nodes", "rabbit@localhost", "memory", "total"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "nodes", "*", "sockets_used"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "nodes", "*", "memory", "mnesia"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "vhosts", "%2f", "message_stats", "deliver_get"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "vhosts", "*", "messages"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "vhosts", "*", "messages_details", "rate"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "exchanges", "*", "*", "message_stats", "publish_in_details", "rate"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "exchanges", "%2f", "snap", "message_stats", "publish_in"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "exchanges", "%2f", "*", "message_stats", "publish_out"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "exchanges", "*", "*", "message_stats", "confirm"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "queues", "%2f", "snapq", "messages_unacknowledged"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "queues", "%2f", "snapq", "messages_details", "rate"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "queues", "%2f", "*", "message_stats", "publish"),
 		},
-		plugin.PluginMetricType{
+		plugin.MetricType{
 			Config_:    cfg.ConfigDataNode,
 			Namespace_: core.NewNamespace("intel", "rabbitmq", "queues", "*", "*", "messages"),
 		},

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -81,5 +81,6 @@ if [[ $TEST_SUITE == "unit" ]]; then
 	# fi
 elif [[ $TEST_SUITE == "integration" ]]; then
 	cd $SNAP_PLUGIN_SOURCE
+	go get github.com/streadway/amqp
 	go test -v --tags=integration ./...
 fi


### PR DESCRIPTION
Updates for integration tests to pass in Travis.
- Download client dependency (amqp) before tests are run
- Update Travis to test Go 1.5.4 and Go 1.6.3.
- plugin.PluginMetricType -> plugin.MetricType changes in integration tests
- Connect to RMQ server to create exchange and queue before running exchange and queue API tests.